### PR TITLE
Added resume and clean options to the bbedit command

### DIFF
--- a/Support/bin/edit
+++ b/Support/bin/edit
@@ -3,7 +3,7 @@
 PATH="${PATH}:/usr/local/bin/:${HOME}/bin"
 
 if which -s bbedit; then
-	bbedit --wait +${MM_LINE_NUMBER} --pipe-title "${MM_TITLE:-(no subject)}" "${MM_EDIT_FILEPATH}"
+	bbedit --wait --resume --clean +${MM_LINE_NUMBER} --pipe-title "${MM_TITLE:-(no subject)}" "${MM_EDIT_FILEPATH}"
 else
 	osascript -e 'tell app "MailMate" to display dialog "Make sure you have the “bbedit” command installed. See the “BBEdit ▸ Install Command Line Tools” menu item within BBEdit." buttons "OK" default button 1 with title "Unable to locate BBEdit"' >/dev/null 2>&1 &
 fi


### PR DESCRIPTION
I frequently activate BBEdit from the command line and have learnt some useful option for the command.
- The "resume" option makes MailMate become the front application after the bundle have run.
- The "clean" option makes BBEdit not ask for the document to be saved if no changes have been made to the text.
